### PR TITLE
Relax whitespace handling around = in breed plan parsing

### DIFF
--- a/breed-web/Cargo.toml
+++ b/breed-web/Cargo.toml
@@ -8,7 +8,7 @@ data = { path = "../data" }
 error = { path = "../error" }
 log = ">=0.4"
 env_logger = ">=0.10"
-warp = ">=0.3"
+warp = { version = "0.4", features = ["server"] }
 tokio = { version = ">=1", features = ["rt-multi-thread"] }
 tera = { version = ">=1", default-features = false }
 serde = { version = ">=1", features = ["derive"] }

--- a/data/src/xml.rs
+++ b/data/src/xml.rs
@@ -180,7 +180,7 @@ impl<'a> Parser<'a>
                     {
                         reader.read_to_end(e.to_end().name()).map_err(
                             |_| xmlerr!("Failed to find end tag of {}.", tag))?;
-                        f(&path, &x[pos_before..reader.buffer_position()])?;
+                        f(&path, &x[pos_before as usize .. reader.buffer_position() as usize])?;
                         path.pop();
                     }
                 },


### PR DESCRIPTION
Fixes Issue #1

This PR relaxes whitespace handling around + and = in breed plan parsing, allowing valid inputs such as:
`Blizzardy + Phoenix = RainHawk `
to parse correctly.

While testing on current Rust, the project did not build due to:
- a u64 slice index in the XML parser, and
- warp::serve being gated behind the server feature.

I included minimal fixes for both in separate commits so the project builds and tests cleanly on modern toolchains.